### PR TITLE
feat: add volatility calculation

### DIFF
--- a/src/calculator.py
+++ b/src/calculator.py
@@ -24,10 +24,16 @@ def calculate_position(
     validator.validate_instrument_ticker(exchange, instrument_ticker)
 
     candle_properties = tools.get_candle_properties(min_hold_time)
+    range_period_size = tools.get_range_period_size(min_hold_time)
     market_data = api.fetch_candlestick_price_data(exchange, instrument_ticker, candle_properties)
+    validator.validate_candlestick_price_data(market_data)
+    price_ranges_min_time = tools.find_price_ranges(market_data, range_period_size)
 
     candle_properties = tools.get_candle_properties(max_hold_time)
+    range_period_size = tools.get_range_period_size(max_hold_time)
     market_data = api.fetch_candlestick_price_data(exchange, instrument_ticker, candle_properties)
+    validator.validate_candlestick_price_data(market_data)
+    price_ranges_max_time = tools.find_price_ranges(market_data, range_period_size)
 
     position = {
         'stop-loss': [],

--- a/src/exchange_api/deribit.py
+++ b/src/exchange_api/deribit.py
@@ -18,6 +18,14 @@ def fetch_candlestick_price_data(ticker, candles_properties):
     try:
         api_response = api_instance.public_get_tradingview_chart_data_get(
             ticker, candles_properties['start_time'], candles_properties['end_time'], candles_properties['resolution'])
-        return api_response['result']
+        return {
+            'length': len(api_response['result']['ticks']),
+            'ticks': api_response['result']['ticks'],
+            'volume': api_response['result']['volume'],
+            'open': api_response['result']['open'],
+            'low': api_response['result']['low'],
+            'high': api_response['result']['high'],
+            'close': api_response['result']['close']
+        }
     except ApiException as error_code:
         errors.deribit_fetch_market_price_data_request_failed(error_code)

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,4 +1,4 @@
-def find_price_ranges(market_price_data, period_size_bars):
+def find_price_ranges(candlestick_data, period_size):
     """Calculates historical price ranges for a given period duration.
 
     For one period of bars ranges counts as:
@@ -6,13 +6,20 @@ def find_price_ranges(market_price_data, period_size_bars):
     2nd range: (first bar opening price - low price in period) / first bar opening price - 1
     The next period is obtained by a shift of always 1 bar.
 
-    :param (dict of str: list) market_price_data: candlestick market price data (required)
-    :param int period_size_bars: size of one period in bars (required)
+    :param (dict of str: list) candlestick_data: candlestick market price data (required)
+    :param int period_size: size of one period in bars (required)
     :return (list of float) price_ranges: all price ranges in market price data
     """
 
     price_ranges = []
-    return price_ranges
+    for candle_index in range(candlestick_data['length'] - period_size + 1):
+        period_open = candlestick_data['open'][candle_index]
+        max_high = max(candlestick_data['high'][candle_index: candle_index + period_size])
+        min_low = min(candlestick_data['low'][candle_index: candle_index + period_size])
+        price_ranges.append(max_high / period_open - 1)
+        price_ranges.append(1 - min_low / period_open)
+    print(sorted(price_ranges))
+    return sorted(price_ranges)
 
 
 def find_order_levels(price_ranges, order_probabilities):
@@ -39,3 +46,12 @@ def get_candle_properties(hold_time):
         'end_time': 0
     }
     return candle_properties
+
+
+def get_range_period_size(hold_time):
+    """
+    Todo: realize function (issue #11)
+    """
+
+    period_size = 0
+    return period_size

--- a/src/validator.py
+++ b/src/validator.py
@@ -3,25 +3,28 @@ import os
 import json
 
 
-def validate_candlestick_price_data(data, candles_amount):
+def validate_candlestick_price_data(data):
     """Validates candlestick market price data
 
     :param (dict of str: list) data: candlestick market price data
-    :param int candles_amount: expected number of candles in data
     :raises TypeError: market price data type is not a dictionary
     :raises ValueError: invalid market price data
     """
 
-    required_keys = ['ticks', 'open', 'high', 'low', 'close']
+    required_keys = ['ticks', 'open', 'high', 'low', 'close', 'length']
+    price_keys = ['ticks', 'open', 'high', 'low', 'close']
     if type(data) is not dict:
         errors.market_data_type_invalid()
     for field in required_keys:
         if field not in data:
             errors.market_data_not_have_key(field)
+
+    length = data['length']
+    for field in price_keys:
         if len(data[field]) == 0:
             errors.market_data_empty(field)
-        if len(data[field]) != candles_amount:
-            errors.market_data_key_size_invalid(field, candles_amount, len(data[field]))
+        if len(data[field]) != length:
+            errors.market_data_key_size_invalid(field, length, len(data[field]))
     return True
 
 

--- a/test/exchanges_api/test_deribit_api.py
+++ b/test/exchanges_api/test_deribit_api.py
@@ -6,76 +6,49 @@ import src.validator as validator
 
 class TestFetchCandlestickPriceData:
     """Tests for fetch_candlestick_price_data function"""
+    ticker_default = 'BTC-PERPETUAL'
+    candle_properties_default = {
+        'resolution': 15,
+        'amount': 100,
+        'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
+        'end_time': (int(time.time())) * 1000
+    }
 
     def test_valid(self):
         """Passing test. Expected: successful request with not empty response"""
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
-        price_data = deribit.fetch_candlestick_price_data(ticker, candle_properties)
-        assert type(price_data) is dict and len(price_data['ticks']) == candle_properties['amount']
+        price_data = deribit.fetch_candlestick_price_data(self.ticker_default, self.candle_properties_default)
+        assert type(price_data) is dict and price_data['length'] == self.candle_properties_default['amount']
 
     def test_invalid_ticker(self):
         """Invalid ticker. Expected: request failed with RuntimeError"""
         ticker = 'INVALID-TICKER'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
         with pytest.raises(RuntimeError):
-            deribit.fetch_candlestick_price_data(ticker, candle_properties)
+            deribit.fetch_candlestick_price_data(ticker, self.candle_properties_default)
 
     def test_invalid_candle_resolution(self):
         """Invalid candle resolution. Expected: request failed with RuntimeError"""
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 9,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
+        candle_properties = self.candle_properties_default.copy()
+        candle_properties['resolution'] = 9
         with pytest.raises(RuntimeError):
-            deribit.fetch_candlestick_price_data(ticker, candle_properties)
+            deribit.fetch_candlestick_price_data(self.ticker_default, candle_properties)
 
     def test_invalid_candle_time(self):
         """Invalid candle start or/and end time. Expected: empty response"""
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': 1500,
-            'end_time': 1000
-        }
-        price_data = deribit.fetch_candlestick_price_data(ticker, candle_properties)
-        assert type(price_data) is dict and len(price_data['ticks']) == 0
+        candle_properties = self.candle_properties_default.copy()
+        candle_properties['start_time'] = 1500
+        candle_properties['end_time'] = 1000
+        price_data = deribit.fetch_candlestick_price_data(self.ticker_default, candle_properties)
+        assert type(price_data) is dict and price_data['length'] == 0
 
     def test_invalid_candles_amount(self):
         """Invalid candles amount. Expected: successful request with not empty response"""
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': -1,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
+        candle_properties = self.candle_properties_default.copy()
+        candle_properties['amount'] = -1
         expected_candles_amount = 100
-        price_data = deribit.fetch_candlestick_price_data(ticker, candle_properties)
-        assert type(price_data) is dict and len(price_data['ticks']) == expected_candles_amount
+        price_data = deribit.fetch_candlestick_price_data(self.ticker_default, candle_properties)
+        assert type(price_data) is dict and price_data['length'] == expected_candles_amount
 
     def test_response_validation(self):
         """Response validation test. Expected: validation passing"""
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
-        price_data = deribit.fetch_candlestick_price_data(ticker, candle_properties)
-        assert validator.validate_candlestick_price_data(price_data, candle_properties['amount'])
+        price_data = deribit.fetch_candlestick_price_data(self.ticker_default, self.candle_properties_default)
+        assert validator.validate_candlestick_price_data(price_data)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,29 +5,23 @@ import src.api as api
 
 class TestFetchCandlestickPriceData:
     """Tests for fetch_candlestick_price_data function"""
+    exchange_default = 'deribit'
+    ticker_default = 'BTC-PERPETUAL'
+    candle_properties_default = {
+            'resolution': 15,
+            'amount': 100,
+            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
+            'end_time': (int(time.time())) * 1000
+        }
 
     def test_valid(self):
         """Passing test. Expected: successful request with not empty response"""
-        exchange = 'deribit'
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
-        price_data = api.fetch_candlestick_price_data(exchange, ticker, candle_properties)
-        assert type(price_data) is dict and len(price_data['ticks']) == candle_properties['amount']
+        price_data = api.fetch_candlestick_price_data(self.exchange_default, self.ticker_default,
+                                                      self.candle_properties_default)
+        assert type(price_data) is dict and price_data['length'] == self.candle_properties_default['amount']
 
     def test_invalid_exchange(self):
-        """Invalid ticker. Expected: request failed with RuntimeError"""
+        """Invalid exchange. Expected: request failed with RuntimeError"""
         exchange = 'invalid-exchange'
-        ticker = 'BTC-PERPETUAL'
-        candle_properties = {
-            'resolution': 15,
-            'amount': 100,
-            'start_time': (int(time.time()) - 99 * 15 * 60) * 1000,
-            'end_time': (int(time.time())) * 1000
-        }
         with pytest.raises(ValueError):
-            api.fetch_candlestick_price_data(exchange, ticker, candle_properties)
+            api.fetch_candlestick_price_data(exchange, self.ticker_default, self.candle_properties_default)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,0 +1,20 @@
+import src.tools as tools
+
+
+class TestFindPriceRanges:
+    """Tests for find_price_ranges function"""
+    candlestick_data_default = {
+        'length': 5,
+        'ticks': [1566183600000, 1566187200000, 1566190800000, 1566194400000, 1566198000000],
+        'open': [10401.5, 10404.0, 10376.0, 10363.5, 10471.5],
+        'low': [10352.0, 10367.5, 10347.0, 10357.0, 10468.5],
+        'high': [10415.0, 10415.0, 10392.5, 10486.0, 10745.0],
+        'close': [10406.0, 10376.0, 10363.5, 10470.5, 10731.0]
+    }
+    period_size_default = 3
+    expected_ranges = [0.0012978897274431578, 0.0027949113338473497, 0.005239628899677884, 0.005478662053056471,
+                       0.007881584006151465, 0.03556283731688503]
+
+    def test_valid(self):
+        """Passing test. Expected: real ranges == expected ranges"""
+        assert self.expected_ranges == tools.find_price_ranges(self.candlestick_data_default, self.period_size_default)

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -1,95 +1,63 @@
 import pytest
-import time
 import src.validator as validator
 
 
 class TestValidateCandlestickPriceData:
     """Tests for validate_candlestick_price_data function"""
+    price_data_default = {
+        'ticks': [1566086400000, 1566090000000, 1566093600000, 1566097200000, 1566100800000],
+        'open': [40.11, 40.21, 40.31, 40.01, 40.41],
+        'high': [40.16, 40.26, 40.36, 40.06, 40.46],
+        'low': [40.06, 40.16, 40.26, 39.96, 40.366],
+        'close': [40.10, 40.20, 40.31, 39.99, 40.41],
+        'length': 5
+    }
 
     def test_valid(self):
         """Passing test. Expected: successful validation"""
-        price_data = {
-            'ticks': [1566086400000, 1566090000000, 1566093600000, 1566097200000, 1566100800000],
-            'open': [40.11, 40.21, 40.31, 40.01, 40.41],
-            'high': [40.16, 40.26, 40.36, 40.06, 40.46],
-            'low': [40.06, 40.16, 40.26, 39.96, 40.366],
-            'close': [40.10, 40.20, 40.31, 39.99, 40.41]
-        }
-        candles_amount = 5
-        assert validator.validate_candlestick_price_data(price_data, candles_amount)
+        assert validator.validate_candlestick_price_data(self.price_data_default)
 
     def test_additional_key(self):
         """Additional optional key in data. Expected: successful validation"""
-        price_data = {
-            'ticks': [1566086400000, 1566090000000, 1566093600000, 1566097200000, 1566100800000],
-            'volume': [10.21, 11.22, 9.23, 3.24, 20.25],
-            'open': [40.11, 40.21, 40.31, 40.01, 40.41],
-            'high': [40.16, 40.26, 40.36, 40.06, 40.46],
-            'low': [40.06, 40.16, 40.26, 39.96, 40.366],
-            'close': [40.10, 40.20, 40.31, 39.99, 40.41]
-        }
-        candles_amount = 5
-        assert validator.validate_candlestick_price_data(price_data, candles_amount)
+        price_data = self.price_data_default.copy()
+        price_data['volume'] = [10.21, 11.22, 9.23, 3.24, 20.25]
+        assert validator.validate_candlestick_price_data(price_data)
 
     def test_invalid_type(self):
         """Price data invalid type. Expected: validation failed with TypeError"""
-        price_data = [
-            [1566086400000, 1566090000000, 1566093600000, 1566097200000, 1566100800000],
-            [40.11, 40.21, 40.31, 40.01, 40.41],
-            [40.16, 40.26, 40.36, 40.06, 40.46],
-            [40.06, 40.16, 40.26, 39.96, 40.366],
-            [40.10, 40.20, 40.31, 39.99, 40.41]
-        ]
-        candles_amount = 5
+        price_data = self.price_data_default.items()
         with pytest.raises(TypeError):
-            validator.validate_candlestick_price_data(price_data, candles_amount)
+            validator.validate_candlestick_price_data(price_data)
 
     def test_missing_key(self):
         """One key is missing. Expected: validation failed with ValueError"""
-        price_data = {
-            'open': [40.11, 40.21, 40.31, 40.01, 40.41],
-            'high': [40.16, 40.26, 40.36, 40.06, 40.46],
-            'low': [40.06, 40.16, 40.26, 39.96, 40.366],
-            'close': [40.10, 40.20, 40.31, 39.99, 40.41]
-        }
-        candles_amount = 5
+        price_data = self.price_data_default.copy()
+        del price_data['ticks']
         with pytest.raises(ValueError):
-            validator.validate_candlestick_price_data(price_data, candles_amount)
+            validator.validate_candlestick_price_data(price_data)
 
     def test_empty_key(self):
         """One key is empty. Expected: validation failed with ValueError"""
-        price_data = {
-            'ticks': [],
-            'open': [40.11, 40.21, 40.31, 40.01, 40.41],
-            'high': [40.16, 40.26, 40.36, 40.06, 40.46],
-            'low': [40.06, 40.16, 40.26, 39.96, 40.366],
-            'close': [40.10, 40.20, 40.31, 39.99, 40.41]
-        }
-        candles_amount = 5
+        price_data = self.price_data_default.copy()
+        price_data['ticks'] = []
         with pytest.raises(ValueError):
-            validator.validate_candlestick_price_data(price_data, candles_amount)
+            validator.validate_candlestick_price_data(price_data)
 
     def test_invalid_candles_amount(self):
         """One key has fewer or more candles than expected. Expected: validation failed with ValueError"""
-        price_data = {
-            'ticks': [1566086400000, 1566090000000, 1566093600000, 1566097200000, 1566100800000],
-            'open': [40.11, 40.21, 40.31, 40.01, 40.41],
-            'high': [40.16, 40.26, 40.36, 40.06, 40.46],
-            'low': [40.06, 40.16, 40.26, 39.96, 40.366],
-            'close': [40.10, 40.20, 40.31, 39.99, 40.41]
-        }
-        candles_amount = 4
+        price_data = self.price_data_default.copy()
+        price_data['length'] = 4
         with pytest.raises(ValueError):
-            validator.validate_candlestick_price_data(price_data, candles_amount)
+            validator.validate_candlestick_price_data(price_data)
 
 
 class TestValidateExchangeName:
     """Tests for validate_exchange_name function"""
+    exchange_default = 'deribit'
 
     def test_valid(self):
         """Passing test. Expected: successful validation"""
-        exchange = 'deribit'
-        assert validator.validate_exchange_name(exchange)
+        assert validator.validate_exchange_name(self.exchange_default)
 
     def test_invalid_exchange(self):
         """Invalid exchange. Expected: validation failing"""
@@ -100,23 +68,21 @@ class TestValidateExchangeName:
 
 class TestValidateInstrumentTicker:
     """Tests for validate_instrument_ticker function"""
+    exchange_default = 'deribit'
+    ticker_default = 'BTC-PERPETUAL'
 
     def test_valid(self):
         """Passing test. Expected: successful validation"""
-        exchange = 'deribit'
-        ticker = 'BTC-PERPETUAL'
-        assert validator.validate_instrument_ticker(exchange, ticker)
+        assert validator.validate_instrument_ticker(self.exchange_default, self.ticker_default)
 
     def test_invalid_exchange(self):
         """Invalid exchange. Expected: validation failing"""
         exchange = 'invalid-exchange'
-        ticker = 'BTC'
         with pytest.raises(ValueError):
-            validator.validate_instrument_ticker(exchange, ticker)
+            validator.validate_instrument_ticker(exchange, self.ticker_default)
 
     def test_invalid_ticker(self):
         """Invalid ticker. Expected: validation failing"""
-        exchange = 'deribit'
         ticker = 'INVLD-TCKR'
         with pytest.raises(ValueError):
-            validator.validate_instrument_ticker(exchange, ticker)
+            validator.validate_instrument_ticker(self.exchange_default, ticker)


### PR DESCRIPTION
Add:
- Historical volatility calculation as price range between max/min and open price
- New parameter `length` in api response in `fetch_candlestick_price_data`
- Test for implemented volatility calculation

Refactoring:
- Data for tests

Closes #6